### PR TITLE
Pass callback to handle routing for DataCatalog

### DIFF
--- a/app/(datasets)/data-catalog/catalog.tsx
+++ b/app/(datasets)/data-catalog/catalog.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useCallback } from 'react';
+import React from 'react';
 import { CatalogView, useFiltersWithQS } from '@lib';
 import { useRouter } from 'next/navigation';
 
@@ -7,9 +7,9 @@ export default function Catalog({ datasets }: { datasets: any }) {
   const controlVars = useFiltersWithQS();
   const router = useRouter();
 
-  const handleCardNavigation = useCallback((path: string) => {
+  const handleCardNavigation = (path: string) => {
     router.push(path);
-  }, [router]);
+  };
 
   return (
     <CatalogView

--- a/app/(datasets)/data-catalog/catalog.tsx
+++ b/app/(datasets)/data-catalog/catalog.tsx
@@ -1,22 +1,21 @@
 'use client';
-import React from 'react';
+import React, { useCallback } from 'react';
 import { CatalogView, useFiltersWithQS } from '@lib';
-import { usePathname } from 'next/navigation';
-import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 export default function Catalog({ datasets }: { datasets: any }) {
-  const pathname = usePathname();
   const controlVars = useFiltersWithQS();
+  const router = useRouter();
+
+  const handleCardNavigation = useCallback((path: string) => {
+    router.push(path);
+  }, [router]);
 
   return (
     <CatalogView
       datasets={datasets}
       onFilterChanges={() => controlVars}
-      pathname={pathname}
-      linkProperties={{
-        LinkElement: Link,
-        pathAttributeKeyName: 'href',
-      }}
+      onCardNavigate={handleCardNavigation}
     />
   );
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "fix": "yarn run format && yarn run lint:fix"
   },
   "dependencies": {
-    "@developmentseed/veda-ui": "v5.11.3-ph-a",
+    "@developmentseed/veda-ui": "v5.11.3-alpha.0",
     "@devseed-ui/theme-provider": "^4.1.0",
     "@tailwindcss/postcss": "4.0.0-alpha.13",
     "@types/node": "20.11.17",


### PR DESCRIPTION
## Available PR templates
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/1108
**Related PR:** https://github.com/NASA-IMPACT/veda-ui/pull/1310

<!--
  Github doesn't allow PR template selection the same way that it is possible with issues.
  Preview this and select the appropriate template
-->

- [Default](?expand=1&template=default.md)
- [Version Release](?expand=1&template=version_release.md)
- _Alternatively delete and start empty_
