### PR TITLE
chore: Separate public dotenv and local dotenv

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_API_STAC_ENDPOINT='https://openveda.cloud/api/stac'
+NEXT_PUBLIC_API_RASTER_ENDPOINT='https://openveda.cloud/api/raster'

--- a/.env.local-sample
+++ b/.env.local-sample
@@ -1,6 +1,6 @@
 # Get your public token from Mapbox dashboard
 # Then copy this file, name it as .env.local
-NEXT_PUBLIC_MAPBOX_TOKEN='your-mapbox-token-here'
+NEXT_PUBLIC_MAPBOX_TOKEN=''
 
 # Google Tag Manager tracking code
 # Not required unless you are actively developing

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files
-.env
+.env.local
 
 # vercel
 .vercel


### PR DESCRIPTION
I am not sure how everybody is developing without this env var - am I missing anything?😅 

Separate public dotenv from local dotenv, saved stac + raster api endpoint for public dotenv. 
Rename `.local.env` to `local.env-sample` 