### PR TITLE
Explicitly parse mapLable as funciton on client side

### DIFF
--- a/app/store/providers/data.tsx
+++ b/app/store/providers/data.tsx
@@ -14,12 +14,13 @@ export function useDataStore() {
   return useContext<DataStore>(DataContext);
 }
 
+// @TODO: Decided how to handle function as mapLabel from VEDA UI
+// https://github.com/NASA-IMPACT/veda-ui/issues/1377
 function updateMapLabels(data) {
   return data.map((dataset) => {
     if (dataset.metadata && dataset.metadata.layers) {
       dataset.metadata.layers.forEach((layer) => {
         if (layer.mapLabel) {
-          // Is there any other way to handle this.
           layer.mapLabel = eval(layer.mapLabel);
         }
         if (layer.compare && layer.compare.mapLabel) {
@@ -30,6 +31,7 @@ function updateMapLabels(data) {
     return dataset;
   });
 }
+
 function DataProvider({
   initialDatasets = undefined,
   children,

--- a/app/store/providers/data.tsx
+++ b/app/store/providers/data.tsx
@@ -14,6 +14,22 @@ export function useDataStore() {
   return useContext<DataStore>(DataContext);
 }
 
+function updateMapLabels(data) {
+  return data.map((dataset) => {
+    if (dataset.metadata && dataset.metadata.layers) {
+      dataset.metadata.layers.forEach((layer) => {
+        if (layer.mapLabel) {
+          // Is there any other way to handle this.
+          layer.mapLabel = eval(layer.mapLabel);
+        }
+        if (layer.compare && layer.compare.mapLabel) {
+          layer.compare.mapLabel = eval(layer.compare.mapLabel);
+        }
+      });
+    }
+    return dataset;
+  });
+}
 function DataProvider({
   initialDatasets = undefined,
   children,
@@ -21,7 +37,9 @@ function DataProvider({
   children: JSX.Element | ReactNode;
   initialDatasets: any[] | undefined;
 }) {
-  const [datasets, setDatasets] = useState<any[] | undefined>(initialDatasets);
+  const [datasets, setDatasets] = useState<any[] | undefined>(
+    updateMapLabels(initialDatasets),
+  );
   const value = {
     datasets,
     setDatasets,


### PR DESCRIPTION
Context: Anything prefixed with `::js` was being parsed as functions (not string) through parcel resolver's virtual module in the original instance. +  Next explicitly prohibits function to be passed as data (it makes sense for security) 


The only way to actually make mapLabel work like a function is `eval` it  on client side - it is gross (that it opens the possibility of running malicious code). I am contemplating that we should make this refactor as an opportunity to rethink mapLabel - ex. instead of passing function, people can just pass the string template. Anyway, opening this for discussion.

---
update: This change doesn't introduce any new problem, so I changed my mind to have this temporary solution while we working on a better solution from UI side.
