### PR TITLE
Add Pagehero for Story Overview Page

### DIFF
--- a/app/(datasets)/stories/[slug]/page.tsx
+++ b/app/(datasets)/stories/[slug]/page.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { notFound } from 'next/navigation';
 import { CustomMDX } from 'app/components/mdx';
-import { formatDate } from 'app/content/utils/date';
 import { getStories } from 'app/content/utils/mdx';
-import { baseUrl } from 'app/sitemap';
+import { PageHero } from '@lib';
 
 async function generateStaticParams() {
   const posts = getStories();
@@ -13,47 +12,7 @@ async function generateStaticParams() {
   }));
 }
 
-function generateMetadata({ params }: { params: any }) {
-  const post = getStories().find((post) => post.slug === params.slug);
-  if (!post) {
-    return;
-  }
-
-  const {
-    title,
-    publishedAt: publishedTime,
-    summary: description,
-    image,
-  } = post.metadata;
-  const ogImage = image
-    ? image
-    : `${baseUrl}/og?title=${encodeURIComponent(title)}`;
-
-  return {
-    title,
-    description,
-    openGraph: {
-      title,
-      description,
-      type: 'article',
-      publishedTime,
-      url: `${baseUrl}/content/${post.slug}`,
-      images: [
-        {
-          url: ogImage,
-        },
-      ],
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title,
-      description,
-      images: [ogImage],
-    },
-  };
-}
-
-export default function Blog({ params }: { params: any }) {
+export default function StoryOverview({ params }: { params: any }) {
   const post = getStories().find((post) => post.slug === params.slug);
 
   if (!post) {
@@ -62,37 +21,13 @@ export default function Blog({ params }: { params: any }) {
 
   return (
     <section>
-      <script
-        type='application/ld+json'
-        suppressHydrationWarning
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify({
-            '@context': 'https://schema.org',
-            '@type': 'BlogPosting',
-            headline: post.metadata.title,
-            datePublished: post.metadata.publishedAt,
-            dateModified: post.metadata.publishedAt,
-            description: post.metadata.summary,
-            image: post.metadata.image
-              ? `${baseUrl}${post.metadata.image}`
-              : `/og?title=${encodeURIComponent(post.metadata.title)}`,
-            url: `${baseUrl}/content/${post.slug}`,
-            author: {
-              '@type': 'Person',
-              name: 'My Portfolio',
-            },
-          }),
-        }}
-      />
-      <h1 className='title font-semibold text-2xl tracking-tighter'>
-        {post.metadata.title}
-      </h1>
-      <div className='flex justify-between items-center mt-2 mb-8 text-sm'>
-        <p className='text-sm text-neutral-600 dark:text-neutral-400'>
-          {formatDate(post.metadata.publishedAt)}
-        </p>
-      </div>
       <article className='prose'>
+        <PageHero
+          title={post.metadata.name}
+          description={post.metadata.description}
+          coverSrc={post.metadata.media?.src}
+          coverAlt={post.metadata.media?.alt}
+        />
         <CustomMDX source={post.content} />
       </article>
     </section>

--- a/app/(datasets)/stories/[slug]/page.tsx
+++ b/app/(datasets)/stories/[slug]/page.tsx
@@ -21,6 +21,20 @@ export default function StoryOverview({ params }: { params: any }) {
 
   return (
     <section>
+      <script 
+        type='application/ld+json'
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'Story',
+            title: post.metadata.name,
+            description: post.metadata.description,
+            coverSrc: post.metadata.media?.src,
+            coverAlt: post.metadata.media?.alt
+          }),
+        }}
+      />
       <article className='prose'>
         <PageHero
           title={post.metadata.name}


### PR DESCRIPTION
## Available PR templates
Closes out `Story headers are missing (unless this was intentional?) even though they are in place for the dataset overview page` as part of https://github.com/NASA-IMPACT/veda-ui/issues/1282.

<!--
  Github doesn't allow PR template selection the same way that it is possible with issues.
  Preview this and select the appropriate template
-->

- [Default](?expand=1&template=default.md)
- [Version Release](?expand=1&template=version_release.md)
- _Alternatively delete and start empty_
